### PR TITLE
Using matcher in all of ctrlp's modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,28 +51,26 @@ let g:ctrlp_user_command = {
   \ }
 
 function! g:GoodMatch(items, str, limit, mmode, ispath, crfile, regex)
-  " the Command-T matcher doesn't do regex. Return now if that was requested.
-  if a:regex == 1
-    let [lines, id] = [[], 0]
-    for item in a:items
-      let id += 1
-      try | if !( a:ispath && item == a:crfile ) && (match(item, a:str) >= 0)
-        cal add(lines, item)
-      en | cat | brea | endt
-    endfo
-    return lines
-  end
+
+  let cachefile = ( exists('g:ctrlp_cache_dir') ? g:ctrlp_cache_dir : $HOME.'/.cache/ctrlp' ).'/uni.cache'
+
+  if !( filereadable(cachefile) && a:items == readfile(cachefile) )
+    call writefile(a:items, cachefile)
+  endif
 
   " a:mmode is currently ignored. In the future, we should probably do
   " something about that. the matcher behaves like "full-line".
-  let cmd = g:path_to_matcher . " --limit " . a:limit . " --manifest " . ctrlp#utils#cachefile() . " "
-  if ! g:ctrlp_dotfiles
-    let cmd = cmd . "--no-dotfiles "
+  let cmd = g:path_to_matcher.' --limit '.a:limit.' --manifest '.cachefile.' '
+
+  if !( exists('g:ctrlp_dotfiles') && g:ctrlp_dotfiles )
+    let cmd = cmd.'--no-dotfiles '
   endif
-  let cmd = cmd . a:str
+
+  let cmd = cmd.a:str
   return split(system(cmd))
 
 endfunction
+
 let g:ctrlp_match_func = { 'match': 'g:GoodMatch' }
 ```
 


### PR DESCRIPTION
This updates the "Using with CtrlP.vim" snippet in the readme. The new snippet enables using matcher in all modes (file, buffer, mru, and all the extensions: tag, line, mixed, etc). Whereas the current snippet only allows using matcher in file mode.
