### PR TITLE
Splitting at newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ let g:path_to_matcher = "/path/to/matcher"
 
 let g:ctrlp_user_command = {
   \ 'types': {
-    \ 1: ['.git/', 'cd %s && git ls-files'],
+    \ 1: ['.git/', 'cd %s && git ls-files . --cached --exclude-standard --others'],
+    \ 2: ['.hg/', 'hg --cwd %s locate -I .'],
     \ },
   \ 'fallback': 'find %s -type f'
   \ }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ function! g:GoodMatch(items, str, limit, mmode, ispath, crfile, regex)
     call writefile(a:items, cachefile)
   endif
 
+  if !filereadable(cachefile)
+    return []
+  endif
+
   " a:mmode is currently ignored. In the future, we should probably do
   " something about that. the matcher behaves like "full-line".
   let cmd = g:path_to_matcher.' --limit '.a:limit.' --manifest '.cachefile.' '
@@ -67,7 +71,7 @@ function! g:GoodMatch(items, str, limit, mmode, ispath, crfile, regex)
   endif
 
   let cmd = cmd.a:str
-  return split(system(cmd))
+  return split(system(cmd), "\n")
 
 endfunction
 

--- a/README.md
+++ b/README.md
@@ -43,22 +43,17 @@ $ find . | matcher order
 ```viml
 let g:path_to_matcher = "/path/to/matcher"
 
-let g:ctrlp_user_command = {
-  \ 'types': {
-    \ 1: ['.git/', 'cd %s && git ls-files . --cached --exclude-standard --others'],
-    \ 2: ['.hg/', 'hg --cwd %s locate -I .'],
-    \ },
-  \ 'fallback': 'find %s -type f'
-  \ }
+let g:ctrlp_user_command = ['.git/', 'cd %s && git ls-files . -co --exclude-standard']
 
-function! g:GoodMatch(items, str, limit, mmode, ispath, crfile, regex)
+let g:ctrlp_match_func = { 'match': 'GoodMatch' }
 
-  let cachefile = ( exists('g:ctrlp_cache_dir') ? g:ctrlp_cache_dir : $HOME.'/.cache/ctrlp' ).'/uni.cache'
+function! GoodMatch(items, str, limit, mmode, ispath, crfile, regex)
 
+  " Create a cache file if not yet exists
+  let cachefile = ctrlp#utils#cachedir().'/matcher.cache'
   if !( filereadable(cachefile) && a:items == readfile(cachefile) )
     call writefile(a:items, cachefile)
   endif
-
   if !filereadable(cachefile)
     return []
   endif
@@ -66,17 +61,14 @@ function! g:GoodMatch(items, str, limit, mmode, ispath, crfile, regex)
   " a:mmode is currently ignored. In the future, we should probably do
   " something about that. the matcher behaves like "full-line".
   let cmd = g:path_to_matcher.' --limit '.a:limit.' --manifest '.cachefile.' '
-
   if !( exists('g:ctrlp_dotfiles') && g:ctrlp_dotfiles )
     let cmd = cmd.'--no-dotfiles '
   endif
-
   let cmd = cmd.a:str
+
   return split(system(cmd), "\n")
 
 endfunction
-
-let g:ctrlp_match_func = { 'match': 'g:GoodMatch' }
 ```
 
 # Using with zsh


### PR DESCRIPTION
Again for the "Using with CtrlP.vim" snippet. By default, `split()` splits at whitespaces and this breaks the result if an entry has whitespaces in it. It should be using "\n" instead.

Also changed is how the cache file's location is determined, and the user_command option now uses the shorter form.
