### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ $(EXENAME): main.c matcher.c
 .PHONY: install
 install: $(EXENAME)
 	install -d $(DESTDIR)$(PREFIX)
-	install -m 0755 $@ $(DESTDIR)$(PREFIX)/bin
+	install -m 0755 $< $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
The rule for the 'install' target in the Makefile used $@ where $< was intended, causing 'make install' to fail.
