### PR TITLE
Handle case when no search term is passed in. (Fix for issue #14)

### DIFF
--- a/main.c
+++ b/main.c
@@ -62,8 +62,8 @@ void parse_arguments(int argc, char *argv[])
     opt = getopt_long(argc, argv, optString, longOpts, &longIndex);
   }
 
-	
-  globalArgs.search = argv[argc - 1];
+  globalArgs.search = (optind < argc) ? argv[optind] : "";
+
 	int i = 0;
 	while(globalArgs.search[i] != '\0'){
 		globalArgs.search[i] = tolower(globalArgs.search[i]);

--- a/matcher.c
+++ b/matcher.c
@@ -162,7 +162,9 @@ void score_list(char *abbrev,
                 int limit)
 {
   long i;
+  long abbrev_len;
 
+  abbrev_len = strlen(abbrev);
   item_t items[num_strs];
 
   for (i = 0; i < num_strs; i++) {
@@ -174,7 +176,8 @@ void score_list(char *abbrev,
 
   if (num_strs < limit) limit = num_strs;
   for (i = 0; i < limit; i++) {
-    if (items[i].score > 0) {
+    // Filter out 0 score items unless no search term has been passed in
+    if (items[i].score > 0 || abbrev_len == 0) {
       printf("%s", items[i].ptr);
     }
   }


### PR DESCRIPTION
When ctrlp opens, it runs matcher with no search term.
Matcher was not correctly handling this and was
setting the search term to its last command line arg.
Also stopped filtering of zero score items when no
search term is passed. This was causing weird behaviour in ctrlp.

I'm assuming ctrlp has some logic which assumes that if a
term produces no matches then adding characters to that term will
still produce no matches. So when matcher returns no matches initially
then adding characters will not cause ctrlp to update results.
Hence the behaviour where matches don't appear until backspace is pressed.
Fixes issue #14
